### PR TITLE
fix: auto-close GitHub issues when Sentry issues resolved + project filter

### DIFF
--- a/.github/workflows/opencode-autofix.yml
+++ b/.github/workflows/opencode-autofix.yml
@@ -41,7 +41,7 @@ jobs:
           ISSUE_JSON=$(gh api \
             -H "Authorization: Bearer $SENTRY_AUTH_TOKEN" \
             -H "Content-Type: application/json" \
-            "https://de.sentry.io/api/0/organizations/bikramgole/issues/?query=is:unresolved&limit=1&statsPeriod=14d" \
+            "https://de.sentry.io/api/0/organizations/bikramgole/issues/?query=is:unresolved%20project:${PROJECT_SLUG}&limit=1&statsPeriod=14d" \
             --jq '.[0] // empty' 2>/dev/null || echo "")
 
           if [ -z "$ISSUE_JSON" ] || [ "$ISSUE_JSON" = "null" ]; then
@@ -126,9 +126,16 @@ jobs:
           GH_TOKEN: ${{ secrets.GH_PAT }}
         run: |
           SENTRY_NUMERIC_ID="${{ steps.sentry.outputs.sentry_numeric_id }}"
+          ISSUE_ID="${{ steps.sentry.outputs.issue_id }}"
           if [ -n "$SENTRY_NUMERIC_ID" ]; then
             gh api -X PUT \
               -H "Authorization: Bearer ${{ secrets.SENTRY_AUTH_TOKEN }}" \
               "https://de.sentry.io/api/0/issues/$SENTRY_NUMERIC_ID/" \
               -F "status=resolved" --silent 2>/dev/null && echo "Sentry issue resolved" || true
+          fi
+          if [ -n "$ISSUE_ID" ]; then
+            OPEN_ISSUE=$(gh issue list --repo "${{ github.repository }}" --state open --json number,title --jq ".[] | select(.title | contains(\"$ISSUE_ID\")) | .number" 2>/dev/null | head -1)
+            if [ -n "$OPEN_ISSUE" ]; then
+              gh issue close "$OPEN_ISSUE" --repo "${{ github.repository }}" --comment "Auto-closed: Sentry issue $ISSUE_ID was resolved." 2>/dev/null && echo "GitHub issue #$OPEN_ISSUE closed" || true
+            fi
           fi

--- a/.github/workflows/sentry-event-checker.yml
+++ b/.github/workflows/sentry-event-checker.yml
@@ -91,3 +91,19 @@ jobs:
 
             echo "Created issue for $SHORT_ID"
           done
+
+          # Close GitHub issues for Sentry issues that are now resolved
+          PROJECT_SLUG=$(echo "${{ github.repository }}" | cut -d/ -f2 | tr '[:upper:]' '[:lower:]' | sed 's/\./-/g')
+          OPEN_ISSUES=$(gh issue list --repo "${{ github.repository }}" --state open --json title,number --jq '.[] | {number, title}' 2>/dev/null || echo "")
+          if [ -n "$OPEN_ISSUES" ]; then
+            echo "$OPEN_ISSUES" | jq -c '.' | while IFS= read -r issue; do
+              NUM=$(echo "$issue" | jq -r '.number')
+              TITLE=$(echo "$issue" | jq -r '.title')
+              SHORT_ID=$(echo "$TITLE" | grep -oP 'Sentry: \K[A-Z]+-[A-Z0-9]+' || echo "")
+              if [ -z "$SHORT_ID" ]; then continue; fi
+              SENTRY_STATUS=$(gh api -H "Authorization: Bearer $SENTRY_AUTH_TOKEN" "https://de.sentry.io/api/0/organizations/bikramgole/issues/?query=$SHORT_ID&limit=1&statsPeriod=14d" --jq '.[0].status // "resolved"' 2>/dev/null || echo "resolved")
+              if [ "$SENTRY_STATUS" = "resolved" ]; then
+                gh issue close "$NUM" --repo "${{ github.repository }}" --comment "Auto-closed: Sentry issue $SHORT_ID is no longer unresolved." 2>/dev/null && echo "Closed #$NUM ($SHORT_ID)" || true
+              fi
+            done
+          fi


### PR DESCRIPTION
Changes:
1. **Project filter**: Autofix now queries Sentry issues filtered by project slug (derived from repo name), preventing cross-repo contamination.
2. **Auto-close GitHub issues**: After resolving a Sentry issue, the autofix pipeline now finds and closes the corresponding open GitHub issue.
3. **Sentry event checker**: Now also checks open GitHub issues, cross-references with Sentry, and closes any whose Sentry issue is already resolved.